### PR TITLE
Fix Hugging Face CI action when secrets are missing

### DIFF
--- a/.github/workflows/huggingface.yml
+++ b/.github/workflows/huggingface.yml
@@ -22,8 +22,8 @@ jobs:
           HF_SPACE_NAME: ${{ secrets.HF_SPACE_NAME }}
         run: |
           if [ -z "$HF_TOKEN" ] || [ -z "$HF_USERNAME" ] || [ -z "$HF_SPACE_NAME" ]; then
-            echo "Error: Missing Hugging Face Secrets. Please add HF_TOKEN, HF_USERNAME, and HF_SPACE_NAME to GitHub Secrets."
-            exit 1
+            echo "Warning: Missing Hugging Face Secrets. Skipping Hugging Face Sync."
+            exit 0
           fi
           
           # Rename the specific Dockerfile for Hugging Face


### PR DESCRIPTION
Fixes the failing CI action for the "Sync to Hugging Face Space" job by allowing it to gracefully exit when the Hugging Face secrets are not available. This prevents false negatives in PRs/forks when the secrets are not accessible, allowing the rest of the CI suite to pass.

---
*PR created automatically by Jules for task [9997332320124964565](https://jules.google.com/task/9997332320124964565) started by @pavanbadempet*